### PR TITLE
Check Notification exist before any call

### DIFF
--- a/assets/js/hooks/Notify.js
+++ b/assets/js/hooks/Notify.js
@@ -22,7 +22,9 @@ function notifyMe(notification) {
 
 export const Notify = {
     mounted() {
-        Notification.requestPermission()
+        if ("Notification" in window) {
+            Notification.requestPermission()
+        }
 
         this.handleEvent("notify", ({ notification }) => {
             notifyMe(notification)


### PR DESCRIPTION
It's an hotfix to allow iOS and iPad users manage channels.
Because of the JS error, an iOS can't access channel configuration 